### PR TITLE
Corregir error de sintaxis en clase Libro.java

### DIFF
--- a/Libro.java
+++ b/Libro.java
@@ -63,7 +63,7 @@ public class Libro{
             return estado;
         }
 
-        public String getdevolucion(){
+        public String getDevolucion(){
             return devolucion;
         }
     
@@ -108,9 +108,6 @@ public class Libro{
         return estado;
     }
 
-    public String devolucion(){
-        return devolucion;
-    }
         
     //Para mostrar la información del libro
     @Override


### PR DESCRIPTION
Se coloco correctamente el getDevoluciony se eliminó el metodo duplicado "public String devolucion()"  (hace lo mismo que el getter de devolucion